### PR TITLE
Change the TLD of my site

### DIFF
--- a/built-with-eleventy/2ZUJSv8pSt.json
+++ b/built-with-eleventy/2ZUJSv8pSt.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://dgrammatiko.online/",
+  "url": "https://dgrammatiko.dev/",
   "source_url": "https://github.com/dgrammatiko/site",
   "opened_by": "dgrammatiko",
   "_backup_opened_by": "twitter:dgrammatiko"


### PR DESCRIPTION
I switched the site from `dgrammatiko.online` to `dgrammatiko.dev`. Of course the `.online` is redirecting to `.dev` but would be nice to have the actual active domain.


Thanks