### PR TITLE
Fix URL in migrated builtwith site

### DIFF
--- a/built-with-eleventy/FHYlAvHyKt.json
+++ b/built-with-eleventy/FHYlAvHyKt.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://www.artofmusic.lu/www.artofmusic.lu/en",
+  "url": "https://www.artofmusic.lu/en",
   "opened_by": "delucis",
   "_backup_opened_by": "twitter:swithinbank"
 }


### PR DESCRIPTION
Seems to be the only one I can see but after migration this URL somehow got mangled — this PR restores it to its former glory ✨ 