### PR TITLE
Delete fluid-type-scale

### DIFF
--- a/built-with-eleventy/swt7-YdyDq.json
+++ b/built-with-eleventy/swt7-YdyDq.json
@@ -1,6 +1,0 @@
-{
-  "url": "https://www.fluid-type-scale.com/",
-  "source_url": "https://github.com/AleksandrHovhannisyan/fluid-type-scale-calculator",
-  "opened_by": "AleksandrHovhannisyan",
-  "_backup_opened_by": "twitter:hovhaDovah"
-}


### PR DESCRIPTION
Loved using 11ty/Slinkity for v1 of this project!

I've migrated it to a different framework, but I'm hoping to bring it back one day and use Slinkity with 11ty Serverless once that's supported. Removing it from the site in the meantime.

Thanks!