### PR TITLE
Update domain and repo name

### DIFF
--- a/built-with-eleventy/QFYycXpHeC.json
+++ b/built-with-eleventy/QFYycXpHeC.json
@@ -1,6 +1,6 @@
 {
-  "url": "https://berly.kim/",
-  "source_url": "https://github.com/querkmachine/berly.kim",
+  "url": "https://beeps.website/",
+  "source_url": "https://github.com/querkmachine/beeps.website",
   "authors": [],
   "opencollective": "",
   "business_url": "",


### PR DESCRIPTION
The domain name and repository have since changed locations, though the old domain name should keep working in perpituity.