### PR TITLE
Removes xtdb.com

### DIFF
--- a/built-with-eleventy/RwSR7rG32y.json
+++ b/built-with-eleventy/RwSR7rG32y.json
@@ -1,5 +1,0 @@
-{
-  "url": "https://xtdb.com/",
-  "opened_by": "saneef",
-  "_backup_opened_by": "twitter:saneef"
-}


### PR DESCRIPTION
The new xtdb.com is not using Eleventy.
