### PR TITLE
Update URL for O-CiJbYgKL

### DIFF
--- a/built-with-eleventy/O-CiJbYgKL.json
+++ b/built-with-eleventy/O-CiJbYgKL.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://pride-flags.fynn.be/",
+  "url": "https://flag.is/",
   "source_url": "https://github.com/mvsde/pride-flags",
   "authors": [
     "mvsde"


### PR DESCRIPTION
The domain for the website changed to [flag.is](https://flag.is/).