### PR TITLE
Remove lamprecht-rechtsanwaelte.de

### DIFF
--- a/built-with-eleventy/7o_n75Wgw9.json
+++ b/built-with-eleventy/7o_n75Wgw9.json
@@ -1,6 +1,0 @@
-{
-  "url": "https://www.lamprecht-rechtsanwaelte.de/",
-  "source_url": "",
-  "opencollective": "lene",
-  "opened_by": "madrilene"
-}


### PR DESCRIPTION
I don't want it to show up anymore, it does not represent how I work nowadays. 