### PR TITLE
Update source URL (7fuy4GBWJE)

### DIFF
--- a/built-with-eleventy/7fuy4GBWJE.json
+++ b/built-with-eleventy/7fuy4GBWJE.json
@@ -1,6 +1,6 @@
 {
   "url": "https://atom-editor.cc/",
-  "source_url": "https://github.com/atom-editor-cc/atom-editor.cc",
+  "source_url": "https://codeberg.org/jgarber/atom-editor.cc",
   "authors": [],
   "opencollective": "jgarber",
   "business_url": "",


### PR DESCRIPTION
Updates source URL from old GitHub URL to Codeberg.

https://codeberg.org/jgarber/atom-editor.cc